### PR TITLE
Ändrade formulering för HP-beräkningsrubrikerna.

### DIFF
--- a/app/results/view.js
+++ b/app/results/view.js
@@ -59,8 +59,8 @@ $("#info-container").append("<div id='statistics-div' class='col-xs-4'></div>");
 $("#statistics-div").append('<h1>Statistik<span id="statistics-info" class="custom-icon">i</span></h1>');
 $("#statistics-div").append("<h3>Avancerade hp: <span id='sum-advanced-points' class='number-value'></span></h3>");
 $("#statistics-div").append("<h3 style='margin-top:5px;'>Grundläggande hp: <span class='number-value'id='sum-other-points'></span></h3>");
-$("#statistics-div").append("<h3 style='margin-top:5px;'>Utlands hp: <span class='number-value' id='sum-abroad-n-test-points'></span></h3>");
-$("#statistics-div").append("<h3 style='margin-top:5px;'>Totalt hp: <span class='number-value'" +
+$("#statistics-div").append("<h3 style='margin-top:5px;'>Utländska hp: <span class='number-value' id='sum-abroad-n-test-points'></span></h3>");
+$("#statistics-div").append("<h3 style='margin-top:5px;'>Totala hp: <span class='number-value'" +
     " id='sum-total-points'></span></h3>");
 
 


### PR DESCRIPTION
Hej,
Det här är någonting av en tämligen pedantisk förändringsförfrågan vilket kan irritera vissa källkodsägare. Men vi hoppas på det bästa och kör på med förklaringen:

Skrev om titlarna så att samtliga hamnade i samma böjningsform. Kan tyvärr inte den precisa grammatiska benämningen, men jag tror att ni förstår.

```
Avancerade hp: 
Grundläggande hp:
Utlands hp: -> Utländska hp:
Totalt hp: -> Totala hp:
```
